### PR TITLE
ci(deps): use the BitGo fork of install-github-release-binary

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,15 +1,30 @@
 {
-  "extends": ["config:base"],
-  "labels": ["dependencies"],
-  "assignees": ["@ericcrosson"],
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "assignees": [
+    "@ericcrosson"
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
     },
     {
-      "matchPackageNames": ["EricCrosson/install-github-release-binary"],
-      "minimumReleaseAge": ["4 weeks"],
+      "matchPackageNames": [
+        "BitGo/install-github-release-binary"
+      ],
+      "minimumReleaseAge": [
+        "4 weeks"
+      ],
       "enabled": true
     }
   ],

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -25,7 +25,7 @@ runs:
         fetch-depth: 0
 
     - name: Install is-semantic-release-configured
-      uses: EricCrosson/install-github-release-binary@v2.4.38
+      uses: BitGo/install-github-release-binary@v2.4.38
       with:
         targets: EricCrosson/is-semantic-release-configured@v1
 


### PR DESCRIPTION
This replaces a third-party dependency with a fork of that dependency,
maintained by Velocity. This is part of an effort to reduce the
amount of toil involved in our maintenance process, and improve our
security posture.

Ticket: VL-2611