### PR TITLE
feat: use vendored semetic-release-major-tag dependency

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
     "@semantic-release/changelog",
     "@semantic-release/git",
     [
-      "semantic-release-major-tag",
+      "@bitgo-private/semantic-release-major-tag",
       {
         "customTags": ["v${major}", "v${major}.${minor}"],
         "includePrerelease": true

--- a/semantic-release/.npmrc
+++ b/semantic-release/.npmrc
@@ -1,0 +1,3 @@
+@bitgo-private:registry=https://private-199765120567.d.codeartifact.us-west-2.amazonaws.com/npm/npm_private/
+//private-199765120567.d.codeartifact.us-west-2.amazonaws.com/npm/npm_private/:always-auth=true
+//private-199765120567.d.codeartifact.us-west-2.amazonaws.com/npm/npm_private/:_authToken=${AWS_CODEARTIFACT_TOKEN}

--- a/semantic-release/.releaserc.json
+++ b/semantic-release/.releaserc.json
@@ -5,7 +5,7 @@
     "@semantic-release/changelog",
     "@semantic-release/git",
     [
-      "semantic-release-major-tag",
+      "@bitgo-private/semantic-release-major-tag",
       {
         "customTags": ["v${major}", "v${major}.${minor}"],
         "includePrerelease": true

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -75,6 +75,7 @@ runs:
     - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false'
       run: |
         : install semantic-release manifest
+        cp "${{ github.action_path }}/.npmrc" "${{ env.node_workdir }}/.npmrc"
         cp "${{ github.action_path }}/package.json" "${{ env.node_workdir }}/package.json"
         cp "${{ github.action_path }}/package-lock.json" "${{ env.node_workdir }}/package-lock.json"
         cp "${{ github.action_path }}/.releaserc.json" ".releaserc.json"

--- a/semantic-release/package-lock.json
+++ b/semantic-release/package-lock.json
@@ -7,10 +7,10 @@
     "": {
       "name": "@semantic-release-action/github-actions",
       "dependencies": {
+        "@bitgo-private/semantic-release-major-tag": "1.0.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
-        "semantic-release": "25.0.2",
-        "semantic-release-major-tag": "0.3.2"
+        "semantic-release": "25.0.2"
       }
     },
     "node_modules/@actions/core": {
@@ -74,6 +74,14 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bitgo-private/semantic-release-major-tag": {
+      "version": "1.0.0",
+      "resolved": "https://private-199765120567.d.codeartifact.us-west-2.amazonaws.com/npm/npm_private/@bitgo-private/semantic-release-major-tag/-/semantic-release-major-tag-1.0.0.tgz",
+      "integrity": "sha512-oLma+zRiW0JDU3hPyzCLsjymtAFU0Rjw8+Oc5XvA6GYS1bagRtjBdzNxVm36Up5IHHMRdfPozwm0e7sss2EYdA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@colors/colors": {
@@ -4604,14 +4612,6 @@
         "node": "^22.14.0 || >= 24.10.0"
       }
     },
-    "node_modules/semantic-release-major-tag": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/semantic-release-major-tag/-/semantic-release-major-tag-0.3.2.tgz",
-      "integrity": "sha512-XTB3mVG6D6oPHSW/zhWC3eSoBRiLqZjKtjTc90wcLzS0DG00UORnn7CceDGdYc5dIl0BG91eO873HvECimyE+Q==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -5571,6 +5571,11 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+    },
+    "@bitgo-private/semantic-release-major-tag": {
+      "version": "1.0.0",
+      "resolved": "https://private-199765120567.d.codeartifact.us-west-2.amazonaws.com/npm/npm_private/@bitgo-private/semantic-release-major-tag/-/semantic-release-major-tag-1.0.0.tgz",
+      "integrity": "sha512-oLma+zRiW0JDU3hPyzCLsjymtAFU0Rjw8+Oc5XvA6GYS1bagRtjBdzNxVm36Up5IHHMRdfPozwm0e7sss2EYdA=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -8677,11 +8682,6 @@
           "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
         }
       }
-    },
-    "semantic-release-major-tag": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/semantic-release-major-tag/-/semantic-release-major-tag-0.3.2.tgz",
-      "integrity": "sha512-XTB3mVG6D6oPHSW/zhWC3eSoBRiLqZjKtjTc90wcLzS0DG00UORnn7CceDGdYc5dIl0BG91eO873HvECimyE+Q=="
     },
     "semver": {
       "version": "7.7.3",

--- a/semantic-release/package.json
+++ b/semantic-release/package.json
@@ -2,9 +2,9 @@
   "name": "@semantic-release-action/github-actions",
   "private": true,
   "dependencies": {
+    "@bitgo-private/semantic-release-major-tag": "1.0.0",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "semantic-release": "25.0.2",
-    "semantic-release-major-tag": "0.3.2"
+    "semantic-release": "25.0.2"
   }
 }


### PR DESCRIPTION
Ticket: DX-2438

This PR swaps the usage of `semantic-release-major-tag` to our vendored version.