### PR TITLE
fix: remove @semantic-release/git to fix CI

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,6 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/git",
     [
       "semantic-release-major-tag",
       {


### PR DESCRIPTION
## Summary

Release workflow is currently failing: https://github.com/BitGo/semantic-release-github-actions/actions/runs/24463957374

- Remove `@semantic-release/git` from `.releaserc.json`
- Branch protection policy blocks the git push this plugin attempts after each release
- The `host_release.yml` workflow runs semantic-release directly and cannot use the composite action's `disable-semantic-release-git` input, so the fix is to remove the plugin from `.releaserc.json` entirely

## Test plan

- [ ] Merge and verify the release CI workflow completes successfully without a git push error

Tick: DX-717

🤖 Generated with [Claude Code](https://claude.ai/code)